### PR TITLE
Fix deduplication of transaction operations

### DIFF
--- a/paritydb/src/database.rs
+++ b/paritydb/src/database.rs
@@ -250,4 +250,24 @@ mod tests {
 
 		assert_eq!(*db.get("a").unwrap_err().kind(), ErrorKind::InvalidKeyLen(3, 1));
 	}
+
+	#[test]
+	fn test_same_key_operation_ordering() {
+		let temp = tempdir::TempDir::new("test_fail").unwrap();
+
+		let mut db = Database::create(temp.path(), Options {
+			journal_eras: 0,
+			key_len: 3,
+			..Default::default()
+		}).unwrap();
+
+		let mut tx = Transaction::default();
+		tx.insert("abc", "123");
+		tx.delete("abc");
+
+		db.commit(&tx).unwrap();
+		db.flush_journal(1).unwrap();
+
+		assert_eq!(db.get("abc").unwrap(), None);
+	}
 }

--- a/paritydb/src/journal.rs
+++ b/paritydb/src/journal.rs
@@ -138,9 +138,13 @@ impl JournalEra {
 
 	/// Returns an iterator over era entries
 	pub fn iter(&self) -> btree_set::IntoIter<Operation> {
-		unsafe { OperationsIterator::new(&self.mmap.as_slice()[CHECKSUM_SIZE..]) }
-			.collect::<BTreeSet<_>>()
-			.into_iter()
+		let mut set = BTreeSet::new();
+
+		for o in unsafe { OperationsIterator::new(&self.mmap.as_slice()[CHECKSUM_SIZE..]) } {
+			set.replace(o);
+		}
+
+		set.into_iter()
 	}
 
 	/// Deletes underlying file


### PR DESCRIPTION
When iterating over a `JournalEra`s operations they are collected into a `BTreeSet` but newer entries need to explicitly replace older ones.